### PR TITLE
Add text conversion feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,17 @@ func main() {
 
 			fmt.Printf("Successfully created PDF file: %s\n", outputFile)
 
+		case ".txt":
+			// Create text writer
+			textWriter := writers.NewTextWriter(outputDir)
+			err = textWriter.WriteTexts(outputFile, content.Text)
+			if err != nil {
+				fmt.Printf("Error creating text file: %v\n", err)
+				return
+			}
+
+			fmt.Printf("Successfully created text file: %s\n", outputFile)
+
 		default:
 			fmt.Printf("Unsupported output format: %s\n", ext)
 		}

--- a/writers/text_writer.go
+++ b/writers/text_writer.go
@@ -1,0 +1,33 @@
+package writers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// TextWriter handles writing plain text files.
+type TextWriter struct {
+	// Output directory for text files
+	OutputDir string
+}
+
+// NewTextWriter creates a new TextWriter.
+func NewTextWriter(outputDir string) *TextWriter {
+	return &TextWriter{OutputDir: outputDir}
+}
+
+// WriteTexts saves the given text to a file.
+func (w *TextWriter) WriteTexts(outputPath string, text string) error {
+	if err := os.MkdirAll(w.OutputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %v", err)
+	}
+
+	outputPath = filepath.Join(w.OutputDir, filepath.Base(outputPath))
+	return os.WriteFile(outputPath, []byte(text), 0644)
+}
+
+// Write writes sample text to the specified file.
+func (w *TextWriter) Write(outputPath string) error {
+	return w.WriteTexts(outputPath, "Sample Text")
+}


### PR DESCRIPTION
## Summary
- add `TextWriter` for plain text output
- allow `.txt` output in CLI `convert` command

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859ef82fd088333bd8dce9aa7ef4e4a